### PR TITLE
In method create_repository(), 'create_structure' option should only be ...

### DIFF
--- a/lib/beanstalkapi.class.php
+++ b/lib/beanstalkapi.class.php
@@ -599,10 +599,11 @@ class BeanstalkAPI {
 				$xml->addChild('type_id', $type_id);
 		
 			$xml->addChild('title', $title);
-		
-			if(!is_null($create_structure))
-				$xml->addChild('create_structure', $create_structure);
-		
+
+			// 'create_structure' option applies to SVN only
+			if ($type_id == 'subversion' && !is_null($create_structure))
+					$xml->addChild('create_structure', $create_structure);
+
 			if(!is_null($color_label))
 				$xml->addChild('color_label', "label-" . $color_label);
 		
@@ -618,10 +619,11 @@ class BeanstalkAPI {
 				$data_array['repository']['type_id'] = $type_id;
 			
 			$data_array['repository']['title'] = $title;
-			
-			if(!is_null($create_structure))
-				$data_array['repository']['create_structure'] = $create_structure;
-			
+
+			// 'create_structure' option applies to SVN only
+			if ($type_id == 'subversion' && !is_null($create_structure))
+					$data_array['repository']['create_structure'] = $create_structure;
+
 			if(!is_null($color_label))
 				$data_array['repository']['color_label'] = "label-" . $color_label;
 			


### PR DESCRIPTION
In method create_repository(), 'create_structure' option should only be used when creating an SVN repo, or creation will fail.

This is described on http://api.beanstalkapp.com/repository.html in the "Writable attributes" section - but I've experienced the issue first hand.  This commit resolves it for me.
